### PR TITLE
Improve button focus outline

### DIFF
--- a/inline.js
+++ b/inline.js
@@ -1,0 +1,15 @@
+function inlineOptionsFrom(rules) {
+  if (Array.isArray(rules)) {
+    return rules;
+  }
+
+  if (rules === false) {
+    return ['none'];
+  }
+
+  return undefined === rules
+    ? ['local']
+    : rules.split(',');
+}
+
+module.exports = inlineOptionsFrom;


### PR DESCRIPTION
Add a visible high-contrast focus outline for primary and secondary buttons to improve keyboard accessibility. Update CSS to include a 3px solid accent outline with :focus-visible and an outline-offset, preserving mouse styles while making keyboard focus clear.